### PR TITLE
Minor bug fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Created by .ignore support plugin (hsz.mobi)
+/.idea/*

--- a/packer/README.md
+++ b/packer/README.md
@@ -9,15 +9,15 @@ Make sure to have [Packer](https://packer.io/) installed, then:
     export AWS_SECRET_ACCESS_KEY=<your secret key>
     export AWS_DEFAULT_REGION=us-east-1
     export SUBNET_ID=subnet-abcd1234 # VPC subnet ID for packer-created instance
-    export BASE_AMI=ami-abcd1234 # [Ubuntu cloud image](https://cloud-images.ubuntu.com/trusty/). Use 64-bit HVM SSD
+    export SOURCE_AMI=ami-abcd1234 # [Ubuntu cloud image](https://cloud-images.ubuntu.com/trusty/). Use 64-bit HVM SSD
     export VPC_ID=vpc-abcd1234 # VPC ID for packer-created instance 
  
     /usr/local/bin/packer build \
-        -var 'description=HA-NAT' \ 
+        -var "description=HA-NAT" \ 
         -var "aws_access_key=${AWS_ACCESS_KEY_ID}" \
         -var "aws_secret_key=${AWS_SECRET_ACCESS_KEY}" \
         -var "region=${AWS_DEFAULT_REGION}" \
-        -var base_ami="${BASE_AMI}" \
+        -var "source_ami=${SOURCE_AMI}" \
         -var "subnet_id=${SUBNET_ID}" \
         -var "vpc_id=${VPC_ID}" \
         -var "ami_name=${AMI_NAME}" \

--- a/packer/ha-nat.json
+++ b/packer/ha-nat.json
@@ -39,7 +39,7 @@
       "start_retry_timeout": "10m",
       "inline": [
         "sudo mv /tmp/ha-nat.sh /usr/local/bin/ha-nat.sh",
-        "sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) main universe restricted multiverse'",
+        "sudo add-apt-repository \"deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) main universe restricted multiverse\"",
         "sudo apt-get update",
         "sudo apt-get -y upgrade",
         "sudo apt-get -y install python-pip",

--- a/packer/ha-nat.json
+++ b/packer/ha-nat.json
@@ -38,7 +38,8 @@
       "type": "shell",
       "start_retry_timeout": "10m",
       "inline": [
-        "sudo mv /tmp/ha-nat.sh /usr/local/bin/ha-nat.sh",
+        "sudo mv /tmp/ha-nat.sh /usr/local/bin/ha-nat.sh && sudo chmod u+x /usr/local/bin/ha-nat.sh",
+        "sudo mv /tmp/rc.local /etc/rc.local && sudo chmod 0755 /etc/rc.local",
         "sudo add-apt-repository \"deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) main universe restricted multiverse\"",
         "sudo apt-get update",
         "sudo apt-get -y upgrade",

--- a/packer/rc.local
+++ b/packer/rc.local
@@ -1,0 +1,15 @@
+#!/bin/sh -e
+#
+# rc.local
+#
+# This script is executed at the end of each multiuser runlevel.
+# Make sure that the script will "exit 0" on success or any other
+# value on error.  Effectively, commands in this file will be automatically
+# executed at boot as the root user
+#
+# In order to enable or disable this script just change the execution
+# bits.
+#
+# This file was placed by Packer (http://packer.io) as part of creating a HA NAT AMI.
+#
+/usr/local/bin/ha-nat.sh


### PR DESCRIPTION
- README recommends passing “base_ami” variable, but ha-nat.json was failing because it expected “source_ami”.  Now fixed.
- `add-apt-repository` command includesd a string enclosed in single quotes, so interpolated bash command did not execute, and `sudo apt-get update` command was failing.  Now fixed.

In addition, I noticed that nothing in the current setup sets the `ha_nat.sh` file to automatically boot at start time.  I updated the `ha_nat.json` file to run that command at boot by replacing the `/etc/rc.local` file, but since this is custom-ish, I didn't include that in this Pull Request.

Update: I also add to `chmod u+x /usr/local/bin/ha-nat.sh` before `/etc/rc.local` would work.
